### PR TITLE
Option Key Pattern in getAttributes() is not filtering base `oPermutive` string

### DIFF
--- a/src/js/permutive.js
+++ b/src/js/permutive.js
@@ -77,7 +77,7 @@ class Permutive {
 			}
 
 			// Build a concise key and get the option value
-			const shortKey = key.replace(/^oPermutive(w)(w+)$/, (m, m1, m2) => m1.toLowerCase() + m2);
+			const shortKey = key.replace(/^oPermutive(\w)(\w+)$/, (m, m1, m2) => m1.toLowerCase() + m2);
 			const value = oPermutiveEl.dataset[key];
 
 			// Try parsing the value as JSON, otherwise just set it as a string


### PR DESCRIPTION
*Escape (w)ord pattern in option key regex pattern*
Fixes an error in the RegeEx in `getDataAttributes()`.
In
```
const shortKey = key.replace(/^oPermutive(w)(w+)$/, (m, m1, m2) => m1.toLowerCase() + m2);
```

,the (w)ord patter is not escaped, so the replacement is never executed. It should be changed as follows.
```
const shortKey = key.replace(/^oPermutive(\w)(\w+)$/, (m, m1, m2) => m1.toLowerCase() + m2);
```