### PR TITLE
`init()` should never return an array of instances + minor refactor `mapKeys()`

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,16 @@
 
 <head>
 	<title>Getting Started</title>
-	<meta name="o-permutive" class="o-permutive" data-o-component="o-permutive"
-		data-o-permutive-id="e1c3fd73-dd41-4abd-b80b-4278d52bf7aa"
-		data-o-permutive-key="b2b3b748-e1f6-4bd5-b2f2-26debc8075a" data-o-permutive-pagetype="article"
-		data-o-permutive-apiInfo-userapi="https://ads-api.ft.com/v1/user"
-		data-o-permutive-apiInfo-contentapi="https://ads-api.ft.com/v1/content/5cfae92e-6cc5-11e9-80c7-60ee53e6681d"
-		data-o-permutive-contentid="b2b3b748-e1f6-4bd5-b2f2-26debc8075a"
+	<meta
+		name="o-permutive"
+		class="o-permutive"
+		data-o-component="o-permutive"
+		data-o-permutive-publicApiKeys-id="e1c3fd73-dd41-4abd-b80b-4278d52bf7aa"
+		data-o-permutive-publicApiKeys-key="b2b3b748-e1f6-4bd5-b2f2-26debc8075a"
+		data-o-permutive-pageType="article"
+		data-o-permutive-adsApi-user="https://ads-api.ft.com/v1/user"
+		data-o-permutive-adsApi-content="https://ads-api.ft.com/v1/content/5cfae92e-6cc5-11e9-80c7-60ee53e6681d"
+		data-o-permutive-appInfo-contentId="b2b3b748-e1f6-4bd5-b2f2-26debc8075a"
 	>
 	</meta>
 </head>

--- a/src/js/permutive.js
+++ b/src/js/permutive.js
@@ -5,6 +5,39 @@ import merge from 'lodash.merge';
 
 const ATTRIBUTE_PATTERN = 'oPermutive';
 
+const OPTION_PARENT_NODES = [
+	'adsApi',
+	'appInfo',
+	'contentApi',
+	'contentId',
+	'oComponent',
+	'pageType',
+	'publicApiKeys',
+	'userApi'
+]
+
+const formatOptionName = key => {
+	const keyLower = key.toLowerCase()
+
+	for (const mapped of OPTION_PARENT_NODES) {
+		if (mapped.toLowerCase() === keyLower) {
+			return mapped
+		}
+	}
+
+	return keyLower
+}
+
+const validateOptions = ({ opts, oPermutiveEl }) => {
+	const options = Object.assign({}, opts || Permutive.getDataAttributes(oPermutiveEl));
+
+	if (!options.publicApiKeys) {
+		throw new Error('o-permutive: No public API Keys found in options.');
+	}
+
+	return options;
+}
+
 // TODO Consents can be derived outside of the package and passed in as config.
 function getConsents() {
 	// derive consent options from ft consent cookie
@@ -43,18 +76,14 @@ class Permutive {
 	 * @param {Object} [opts={}] - An options object for configuring the component
 	 */
 	constructor(oPermutiveEl, opts) {
-		const options = Object.assign({}, opts || Permutive.getDataAttributes(oPermutiveEl));
-
-		if(!options.publicApiKeys) {
-			return false;
-		}
-
 		// By default Permutive assumes consent has been given -
 		// we should not run any permutive code when we dont have user
 		// consent for behavioural profiling.
 		if (!getConsents().behavioral) {
 			return false;
 		}
+
+		const options = validateOptions({ opts, oPermutiveEl })
 
 		// Run the Permutive bootstrap code
 		bootstrap(options.publicApiKeys.id, options.publicApiKeys.key);
@@ -75,25 +104,13 @@ class Permutive {
 		}
 	}
 
-	static mapKey(key) {
-		switch(key) {
-			case 'apiinfo':
-				return 'apiInfo';
-			case 'contentapi':
-				return 'contentApi';
-			case 'contentid':
-				return 'contentId';
-			case 'ocomponent':
-				return 'oComponent';
-			case 'pagetype':
-				return 'pageType';
-			case 'userapi':
-				return 'userApi';
-			default:
-				return key;
-		}
-	}
-
+	/**
+	 * Extract the option's path from an attribute name in camelCase form - coming from the component's dataset -
+	 * and returns a single element object.
+	 * @param {String} optKey - The attribute name in camelCase form, taken from the component's dataset. e.g., publicapikeysId
+	 * @param {String} optValue - The value assigned to optKey.
+	 * @returns {Object} - An object containing a single { key: "value" } or { key: { subkey: value } }
+	 */
 	static attributeToOption({ optKey, optValue }) {
 		const regex = new RegExp(`(^${ATTRIBUTE_PATTERN})?([A-Z][a-z]+)`, 'g');
 		const [/* mWhole */, mPrefix, mOpt] = regex.exec(optKey) || [];
@@ -107,8 +124,8 @@ class Permutive {
 		const [/* mWhole2 */, /* mPrefix2 */, mOpt2] = regex.exec(optKey) || [];
 
 		return {
-			[Permutive.mapKey(shortOptKey.toLowerCase())]: mOpt2
-				? { [Permutive.mapKey(mOpt2.toLowerCase())]: optValue }
+			[formatOptionName(shortOptKey)]: mOpt2
+				? { [formatOptionName(mOpt2)]: optValue }
 				: optValue,
 		};
 	}
@@ -142,10 +159,16 @@ class Permutive {
 		if (!(rootEl instanceof HTMLElement)) {
 			rootEl = document.querySelector(rootEl);
 		}
-		if (rootEl instanceof HTMLElement && rootEl.matches('[data-o-component=o-permutive]')) {
-			return new Permutive(rootEl, opts);
+		if (rootEl instanceof HTMLElement) {
+			if (rootEl.matches('[data-o-component="o-permutive"]')) {
+				return new Permutive(rootEl, opts);
+			}
+
+			const permutiveEl = rootEl.querySelector('[data-o-component="o-permutive"]');
+			if (permutiveEl) {
+				return new Permutive(permutiveEl, opts);
+			}
 		}
-		return Array.from(rootEl.querySelectorAll('[data-o-component="o-permutive"]'), rootEl => new Permutive(rootEl, opts));
 	}
 
 	/**

--- a/src/js/permutive.js
+++ b/src/js/permutive.js
@@ -14,19 +14,19 @@ const OPTION_PARENT_NODES = [
 	'pageType',
 	'publicApiKeys',
 	'userApi'
-]
+];
 
 const formatOptionName = key => {
-	const keyLower = key.toLowerCase()
+	const keyLower = key.toLowerCase();
 
 	for (const mapped of OPTION_PARENT_NODES) {
 		if (mapped.toLowerCase() === keyLower) {
-			return mapped
+			return mapped;
 		}
 	}
 
-	return keyLower
-}
+	return keyLower;
+};
 
 const validateOptions = ({ opts, oPermutiveEl }) => {
 	const options = Object.assign({}, opts || Permutive.getDataAttributes(oPermutiveEl));
@@ -36,7 +36,7 @@ const validateOptions = ({ opts, oPermutiveEl }) => {
 	}
 
 	return options;
-}
+};
 
 // TODO Consents can be derived outside of the package and passed in as config.
 function getConsents() {
@@ -83,7 +83,7 @@ class Permutive {
 			return false;
 		}
 
-		const options = validateOptions({ opts, oPermutiveEl })
+		const options = validateOptions({ opts, oPermutiveEl });
 
 		// Run the Permutive bootstrap code
 		bootstrap(options.publicApiKeys.id, options.publicApiKeys.key);

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -21,9 +21,20 @@ function insert(html) {
 
 
 function htmlCode () {
-	const html = `<div>
-		<div class="o-permutive" data-o-component="o-permutive" id="element"></div>
-	</div>
+	const html = `
+		<!doctype html>
+		<html>
+			<head>
+				<meta
+					id="element"
+					class="o-permutive"
+					data-o-component="o-permutive"
+					data-o-permutive-publicApiKeys-id="api-id-123"
+					data-o-permutive-publicApiKeys-key="api-key-456"
+				>
+				</meta>
+			</head>
+		</html>
 	`;
 	insert(html);
 }

--- a/test/oPermutive.test.js
+++ b/test/oPermutive.test.js
@@ -45,13 +45,6 @@ describe("OPermutive", () => {
 			fixtures.reset();
 		});
 
-		// TODO See issue #11
-		//		it("should create a new component array when initialized", () => {
-		//			const boilerplate = OPermutive.init();
-		//			proclaim.equal(boilerplate instanceof Array, true);
-		//			proclaim.equal(boilerplate[0] instanceof OPermutive, true);
-		//		})
-
 		it("should create a single component when initialized with a root element", () => {
 			const boilerplate = OPermutive.init('#element');
 			proclaim.equal(boilerplate instanceof OPermutive, true);


### PR DESCRIPTION
Fixes #11 
* Removed tests that checks for array of Permutive instances returned from `init()`
* Function `formatOptionName()` replaces `Permutive.mapKeys()`
* Changed fixture and declarative demo index.tml accordingly to options accepted by Permutive constructor
