### PR TITLE
Remove lodash.merge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -234,11 +234,6 @@
 				"path-exists": "^3.0.0"
 			}
 		},
-		"lodash.merge": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
-		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
 		"husky": "^2.3.0"
 	},
 	"private": true,
-	"dependencies": {
-		"lodash.merge": "^4.6.1"
-	},
+	"dependencies": {},
 	"husky": {
 		"hooks": {
 			"pre-push": "obt verify && obt test"

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,5 +1,3 @@
-import merge from 'lodash.merge';
-
 const ATTRIBUTE_PATTERN = 'oPermutive';
 const OPTION_PARENT_NODES = [
 	'projectId',
@@ -94,7 +92,7 @@ export function getDataAttributes(oPermutiveEl) {
 		return {};
 	}
 
-	return merge({}, ...Object.keys(oPermutiveEl.dataset)
+	return Object.assign({}, ...Object.keys(oPermutiveEl.dataset)
 		.map((optKey) => attributeToOption({ optKey, optValue: oPermutiveEl.dataset[optKey] }))
 	);
 }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -92,9 +92,10 @@ export function getDataAttributes(oPermutiveEl) {
 		return {};
 	}
 
-	return Object.assign({}, ...Object.keys(oPermutiveEl.dataset)
-		.map((optKey) => attributeToOption({ optKey, optValue: oPermutiveEl.dataset[optKey] }))
-	);
+	const dataFromPermutiveEl = Object.keys(oPermutiveEl.dataset)
+		.map((optKey) => attributeToOption({ optKey, optValue: oPermutiveEl.dataset[optKey] }));
+
+	return Object.assign({}, ...dataFromPermutiveEl);
 }
 
 /**

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -95,6 +95,7 @@ export function getDataAttributes(oPermutiveEl) {
 	const dataFromPermutiveEl = Object.keys(oPermutiveEl.dataset)
 		.map((optKey) => attributeToOption({ optKey, optValue: oPermutiveEl.dataset[optKey] }));
 
+	// TODO: Support for nested declarative options need a deep merge here
 	return Object.assign({}, ...dataFromPermutiveEl);
 }
 


### PR DESCRIPTION
n-ui  tests fail when it seems lodash.merge for some reason. Obejct.assign does the same job in this case