### PR TITLE
Permutive functionality must not run in the preview app - a temporary…

### DIFF
--- a/src/js/permutive.js
+++ b/src/js/permutive.js
@@ -47,7 +47,9 @@ class Permutive {
 	 */
 	static init(opts, el) {
 		// Permutive must not run in the editorial preview functionality
-		if( /^(.*\.)?preview\./.test(window.location.host) ){ return false;}
+		if (typeof window !== 'undefined' && window.location) {
+			if( /^(.*\.)?preview\./.test(window.location.host) ){ return false;}
+		}
 		// No element specified
 		if(!el) {
 			// Try to find an o-permutive element

--- a/src/js/permutive.js
+++ b/src/js/permutive.js
@@ -46,6 +46,8 @@ class Permutive {
 	 * @returns {(Permutive|Array<Permutive>)} - Permutive instance(s)
 	 */
 	static init(opts, el) {
+		// Permutive must not run in the editorial preview functionality
+		if( /^(.*\.)?preview\./.test(window.location.host) ){ return false;}
 		// No element specified
 		if(!el) {
 			// Try to find an o-permutive element


### PR DESCRIPTION
… fix is being tested whereby we check the window.location with a regex and return false if the domain host contains 'preview'