### PR TITLE
A bug was introduced when refactoring the cookie-consent code - 'cook…

### DIFF
--- a/src/js/permutive.js
+++ b/src/js/permutive.js
@@ -34,9 +34,7 @@ class Permutive {
 			instance = this;
 			return instance;
 		}
-		else {
-			throw new Error('o-permutive: Could not initialise. No consent found');
-		}
+
 	}
 
 	/**

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -131,9 +131,7 @@ export function getConsentFromFtCookie() {
 	const match = document.cookie.match(re);
 	if (!match) {
 		// cookie stasis or no consent cookie found
-		return {
-			behavioral: false
-		};
+		return false;
 	}
 	const consentCookie = decodeURIComponent(match[1]);
 


### PR DESCRIPTION
…ie-stasis' state, (where there is no ftconsent cookie present) was not being passed correctly to the bootstrap function