### PR TITLE
Fix for ADS-DEV282 - bug where Permutive segments were still going in…

### DIFF
--- a/demos/src/programmatic.js
+++ b/demos/src/programmatic.js
@@ -4,10 +4,10 @@ import Permutive from '../../main.js';
 let oPermConf = {
 	projectId: "e1c3fd73-dd41-4abd-b80b-4278d52bf7aa",
 	publicApiKey: "b2b3b748-e1f6-4bd5-b2f2-26debc8075a3",
-	consent: true
+	consentFtCookie: true
 };
 
-document.cookie = 'FTConsent=behaviouraladsOnsite%3Aon;';
+document.cookie = 'FTConsent=behaviouraladsOnsite%3Aoff;';
 
 // Initialise oPermutive
 Permutive.init(oPermConf, false);

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -27,12 +27,7 @@ export function bootstrapPolyfill () {
 			}
 		}
 	}(document, window.permutive);
-	window.googletag = window.googletag || {}, window.googletag.cmd = window.googletag.cmd || [], window.googletag.cmd.push(function () {
-		if (0 === window.googletag.pubads().getTargeting("permutive").length) {
-			var g = window.localStorage.getItem("_pdfps");
-			window.googletag.pubads().setTargeting("permutive", g ? JSON.parse(g) : [])
-		}
-	});
+
 }
 
 export function bootstrapConfig (id, key) {
@@ -44,4 +39,10 @@ export function bootstrapConfig (id, key) {
 			e.config = i || {}, e.config.projectId = o, e.config.apiKey = r, e.config.environment = e.config.environment || "production";
 		}
 	}(window.permutive, id, key, {});
+	window.googletag = window.googletag || {}, window.googletag.cmd = window.googletag.cmd || [], window.googletag.cmd.push(function () {
+		if (0 === window.googletag.pubads().getTargeting("permutive").length) {
+			var g = window.localStorage.getItem("_pdfps");
+			window.googletag.pubads().setTargeting("permutive", g ? JSON.parse(g) : [])
+		}
+	});
 }


### PR DESCRIPTION
Fix for ADS-DEV282 - bug where Permutive segments were still going into ad-requesets even if the User has opted-out of behavioraladsOnsite via consent settings.

The fix involves moving the dfp-integration code out of the `bootstrapPolyfil()` function and into the `bootstrapConfig()` function. The `bootstrapPolyfil()` gets called immediately when the package is imported - this is done in order to set-up a "command queue" array that will hold calls to `window.permutive` ready for when the permutive script loads - meaning we can call `window.permutive.identify()` at any time, even before the permutive-script has loaded (it loads asynchronously) and the function will be added to the command queue array and called once the script loads.
The bug was happening because the `bootstrapPolyfil()` does not check for consent. The fix seems very safe from my understanding, simply moving the DFP segment integration code into the `bootstrapConfig()` function will mean that dfp integration code will only run if consent has been given.