### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/declarative.js
+++ b/demos/src/declarative.js
@@ -1,5 +1,5 @@
 import Permutive from '../../main.js';
-import './demo';
+import './demo.js';
 
 document.cookie = 'FTConsent=behaviouraladsOnsite%3Aon;';
 

--- a/demos/src/programmatic.js
+++ b/demos/src/programmatic.js
@@ -1,4 +1,4 @@
-import Permutive from '../../main.js';
+import Permutive from '../../main.js.js';
 
 let oPermConf = {
 	projectId: "e1c3fd73-dd41-4abd-b80b-4278d52bf7aa",

--- a/demos/src/programmatic.js
+++ b/demos/src/programmatic.js
@@ -1,4 +1,4 @@
-import Permutive from '../../main.js.js';
+import Permutive from '../../main.js';
 
 let oPermConf = {
 	projectId: "e1c3fd73-dd41-4abd-b80b-4278d52bf7aa",

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import Permutive from './src/js/permutive';
+import Permutive from './src/js/permutive.js';
 
 const constructAll = function () {
 	Permutive.init();

--- a/src/js/permutive.js
+++ b/src/js/permutive.js
@@ -1,5 +1,5 @@
-import { bootstrapPolyfill, bootstrapConfig } from './bootstrap';
-import { mergeOptions, getConsentFromFtCookie, attachPermutiveScript } from './utils';
+import { bootstrapPolyfill, bootstrapConfig } from './bootstrap.js';
+import { mergeOptions, getConsentFromFtCookie, attachPermutiveScript } from './utils.js';
 
 // Need to polyfill window.permutive so that it's
 // available to public methods of Permutive class

--- a/test/oPermutive.test.js
+++ b/test/oPermutive.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim, sinon */
-import * as fixtures from './helpers/fixtures';
+import * as fixtures from './helpers/fixtures.js';
 
-import oPermutive from './../main';
+import oPermutive from './../main.js';
 
 function resetOPermutive() {
 	oPermutive.resetInstance();


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing