### PR TITLE
ADSDEV-603: Log a warning when spoorID is used in identifyuser calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Use if you wish to make use of Permutive's User Identity Matching features where
 | User IDs Array | userIDs | Array of objects. See example below | yes, see notes | Required if cross device user matching is required |
 
 
-Note: o-permutive will log a warning if you try to use spoorID as a user identifier, it has been deprecated since it causes user duplication issues on permutive end
+Note: o-permutive will log a warning if you try using more than one user identifier, it has been deprecated since it causes user duplication issues on permutive end
 
 _Example:_
 
@@ -131,8 +131,8 @@ _Example:_
 oPermutive.identifyUser([
 	{
 		id: "<userID>",
-		tag: "GUID",
-	},
+		tag: "GUID"
+	}
 ])
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Use if you wish to make use of Permutive's User Identity Matching features where
 | -------------- | ------- | ----------------------------------- | -------------: | -------------------------------------------------- |
 | User IDs Array | userIDs | Array of objects. See example below | yes, see notes | Required if cross device user matching is required |
 
+
+Note: o-permutive will log a warning if you try to use spoorID as a user identifier, it has been deprecated since it causes user duplication issues on permutive end
+
 _Example:_
 
 ```javascript

--- a/src/js/permutive.js
+++ b/src/js/permutive.js
@@ -82,7 +82,14 @@ class Permutive {
 	 * Send User Identity data to Permutive
 	 * @param {Object} userIden
 	 */
-	static identifyUser(userIden) {
+	static identifyUser(userIden = []) {
+
+		// ADSDEV-603: SpoorId shouldn't be used to identify users, to prevent any future use of spoorID, log a warning
+		let hasSpoorID = userIden.filter(iden => iden.tag.toLowerCase() === 'sporeid' || iden.tag.toLowerCase() === 'spoorid').length;
+
+		if (hasSpoorID) {
+			console.warn('[identifyUser]: SpoorID should not be used as a way to identify the user as it causes user duplication issues with Permutive')
+		}
 		window.permutive.identify(userIden);
 	}
 

--- a/src/js/permutive.js
+++ b/src/js/permutive.js
@@ -88,7 +88,7 @@ class Permutive {
 		let hasSpoorID = userIden.filter(iden => iden.tag.toLowerCase() === 'sporeid' || iden.tag.toLowerCase() === 'spoorid').length;
 
 		if (hasSpoorID) {
-			console.warn('[identifyUser]: SpoorID should not be used as a way to identify the user as it causes user duplication issues with Permutive')
+			console.warn('[identifyUser]: SpoorID should not be used as a way to identify the user as it causes user duplication issues with Permutive');
 		}
 		window.permutive.identify(userIden);
 	}

--- a/src/js/permutive.js
+++ b/src/js/permutive.js
@@ -84,11 +84,11 @@ class Permutive {
 	 */
 	static identifyUser(userIden = []) {
 
-		// ADSDEV-603: SpoorId shouldn't be used to identify users, to prevent any future use of spoorID, log a warning
-		let hasSpoorID = userIden.filter(iden => iden.tag.toLowerCase() === 'sporeid' || iden.tag.toLowerCase() === 'spoorid').length;
+		// ADSDEV-603: Multiple user identifiers causes issues with permutive due to duplication
+		let hasMultipleIds = userIden.length > 1;
 
-		if (hasSpoorID) {
-			console.warn('[identifyUser]: SpoorID should not be used as a way to identify the user as it causes user duplication issues with Permutive');
+		if (hasMultipleIds) {
+			console.warn('[identifyUser]: Multiple ids are deprecated and will be removed on the next major, user guid is preffered');
 		}
 		window.permutive.identify(userIden);
 	}


### PR DESCRIPTION
Add a warning about spoorID to prevent future use